### PR TITLE
Fixed typo and added dependency installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SRAfinder
 Use crawler to quickly obtain SRAid based on GEOid
-This tool is used to get SRA information use GSM number.There are some requests to use it:
+This tool is used to get SRA information use GSM number. There are some requests to use it:
 
 1.The input file must be xlsx file, and the sheet contains GSM number must be named as "sheet1".
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Use crawler to quickly obtain SRAid based on GEOid
 This tool is used to get SRA information use GSM number. There are some requests to use it:
 
-1.The input file must be xlsx file, and the sheet contains GSM number must be named as "sheet1".
+1. The input file must be xlsx file, and the sheet contains GSM number must be named as "sheet1".
 
-2.Several python packages are necessary, including "openpyxl,requests,re,xlsxwriter".
+2. Several python packages are necessary, including `openpyxl`, `requests`, `xlsxwriter`. These packages can be installed via command `python3 install -r requirements.txt`.
 
-3.Put the GSM number file and the python file into same directory.
+3. Put the GSM number file and the python file into same directory.
 
 Currently it can only get SRXid,SRRid and layout.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openpyxl
+requests
+xlsxwriter


### PR DESCRIPTION
1. Typos such as missing space ahead of period are fixed
2. It is commonly accepted as a standard for a python package that dependencies should be given in a specific file so that users can easily prepare their environments with a simple command of `python3 install -r requirements.txt`, where both packages and versions can be specified.